### PR TITLE
Update DEBOUNCER.vhd

### DIFF
--- a/Proyecto_maquina_expendedora_VHDL.srcs/sources_1/new/DEBOUNCER.vhd
+++ b/Proyecto_maquina_expendedora_VHDL.srcs/sources_1/new/DEBOUNCER.vhd
@@ -12,7 +12,7 @@ entity DEBOUNCER is
 end DEBOUNCER;
 
 architecture beh of DEBOUNCER is
-    constant CNT_SIZE : integer := 19;
+    constant CNT_SIZE : integer := 20;
     signal btn_prev   : std_logic := '0';
     signal counter    : std_logic_vector(CNT_SIZE downto 0) := (others => '0');
 


### PR DESCRIPTION
Incrementar un bit el contador del debouncer para que el tiempo de comprobación del flip flop sea en torno a 10 ms, lo cual lo podemos considerar suficiente para que asegure que el botón se mantiene en el estado anterior.